### PR TITLE
Add 'properties' which can be accessed in filter functions

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,7 +2,7 @@
 
 const {match} = require('match-feature');
 
-export const whiteList = ['filter', 'style', 'geometry'];
+export const whiteList = ['filter', 'style', 'geometry', 'properties'];
 
 export let ruleCache = {};
 
@@ -85,11 +85,12 @@ export function mergeTrees(matchingTrees, context) {
 
 class Rule {
 
-    constructor(name, parent, style, filter) {
+    constructor(name, parent, style, filter, properties) {
         this.id = Rule.id++;
         this.name = name;
         this.style = style;
         this.filter = filter;
+        this.properties = properties;
         this.parent = parent;
         this.buildFilter();
         this.buildStyle();
@@ -119,15 +120,15 @@ Rule.id = 0;
 
 
 export class RuleLeaf extends Rule {
-    constructor({name, parent, style, filter}) {
-        super(name, parent, style, filter);
+    constructor({name, parent, style, filter, properties}) {
+        super(name, parent, style, filter, properties);
     }
 
 }
 
 export class RuleTree extends Rule {
-    constructor({name, parent, style, rules, filter}) {
-        super(name, parent, style, filter);
+    constructor({name, parent, style, rules, filter, properties}) {
+        super(name, parent, style, filter, properties);
         this.rules = rules || [];
     }
 
@@ -303,6 +304,7 @@ export function matchFeature(context, rules, collectedRules) {
 
     for (let r=0; r < rules.length; r++) {
         let current = rules[r];
+        context.properties = current.properties;
 
         if (current instanceof RuleLeaf) {
 
@@ -326,6 +328,8 @@ export function matchFeature(context, rules, collectedRules) {
                 }
             }
         }
+
+        context.properties = null;
     }
 
     return matched;

--- a/lib/unruly.js
+++ b/lib/unruly.js
@@ -46,7 +46,7 @@ Object.defineProperties(module.exports, {
   __esModule: {value: true}
 });
 var match = require('match-feature').match;
-var whiteList = ['filter', 'style', 'geometry'];
+var whiteList = ['filter', 'style', 'geometry', 'properties'];
 var ruleCache = {};
 function cacheKey(rules) {
   return rules.map((function(r) {
@@ -113,11 +113,12 @@ function mergeTrees(matchingTrees, context) {
   }
   return style;
 }
-var Rule = function Rule(name, parent, style, filter) {
+var Rule = function Rule(name, parent, style, filter, properties) {
   this.id = $Rule.id++;
   this.name = name;
   this.style = style;
   this.filter = filter;
+  this.properties = properties;
   this.parent = parent;
   this.buildFilter();
   this.buildStyle();
@@ -146,8 +147,9 @@ var RuleLeaf = function RuleLeaf($__5) {
       name = $__6.name,
       parent = $__6.parent,
       style = $__6.style,
-      filter = $__6.filter;
-  $traceurRuntime.superConstructor($RuleLeaf).call(this, name, parent, style, filter);
+      filter = $__6.filter,
+      properties = $__6.properties;
+  $traceurRuntime.superConstructor($RuleLeaf).call(this, name, parent, style, filter, properties);
 };
 var $RuleLeaf = RuleLeaf;
 ($traceurRuntime.createClass)(RuleLeaf, {}, {}, Rule);
@@ -157,8 +159,9 @@ var RuleTree = function RuleTree($__5) {
       parent = $__6.parent,
       style = $__6.style,
       rules = $__6.rules,
-      filter = $__6.filter;
-  $traceurRuntime.superConstructor($RuleTree).call(this, name, parent, style, filter);
+      filter = $__6.filter,
+      properties = $__6.properties;
+  $traceurRuntime.superConstructor($RuleTree).call(this, name, parent, style, filter, properties);
   this.rules = rules || [];
 };
 var $RuleTree = RuleTree;
@@ -318,6 +321,7 @@ function matchFeature(context, rules, collectedRules) {
   }
   for (var r = 0; r < rules.length; r++) {
     var current = rules[r];
+    context.properties = current.properties;
     if (current instanceof RuleLeaf) {
       if (doesMatch(current.filter, context)) {
         matched = true;
@@ -332,6 +336,7 @@ function matchFeature(context, rules, collectedRules) {
         }
       }
     }
+    context.properties = null;
   }
   return matched;
 }


### PR DESCRIPTION
Proposing this as a hopefully simpler alternative to: https://github.com/tangrams/tangram/pull/90/files (which predates the separate of rule filtering into its own library).

This does not support hierarchical/inherited properties, only feeding the `properties` at the same level as a `filter` to that filter function. But as we saw in the other branch, it can get messy quickly to support inheritance (without a bigger refactor), and I think the use cases for it are limited or at least not yet well known, so I think having single-level properties for a v1 release is more than sufficient.

cc @iwillig @meetar 
